### PR TITLE
feat(NET-54199): Add Parameters for Timeout and SSL Policy

### DIFF
--- a/modules/nb-psc-l7xlb/main.tf
+++ b/modules/nb-psc-l7xlb/main.tf
@@ -45,6 +45,7 @@ resource "google_compute_target_https_proxy" "https_proxy" {
   url_map          = google_compute_url_map.url_map.id
   ssl_certificates = var.ssl_certificate
   ssl_policy       = var.ssl_policy
+  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {

--- a/modules/nb-psc-l7xlb/main.tf
+++ b/modules/nb-psc-l7xlb/main.tf
@@ -44,6 +44,7 @@ resource "google_compute_target_https_proxy" "https_proxy" {
   name             = "${var.name}-proxy"
   url_map          = google_compute_url_map.url_map.id
   ssl_certificates = var.ssl_certificate
+  ssl_policy       = var.ssl_policy
 }
 
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {

--- a/modules/nb-psc-l7xlb/variables.tf
+++ b/modules/nb-psc-l7xlb/variables.tf
@@ -66,3 +66,9 @@ variable "ssl_policy" {
   type        = string
   default     = null
 }
+
+variable "http_keep_alive_timeout_sec" {
+  description = "(Optional) The timeout for this load balancer. Defaults to 300"
+  type        = string
+  default     = 300
+}

--- a/modules/nb-psc-l7xlb/variables.tf
+++ b/modules/nb-psc-l7xlb/variables.tf
@@ -60,3 +60,9 @@ variable "labels" {
   Default is an empty map.
   EOD
 }
+
+variable "ssl_policy" {
+  description = "(Optional) The ssl policy associated with this load balancer."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Added several properties to the apigee module that allows us to configure SSL policies and HTTP port timeouts. These features were added upon requests from ICS security bots and developers, respectively.

To test:
* Review the changes to configuration
* Review the original requests in the tickets: [SSL Policy Ticket](https://kareodev.atlassian.net/browse/NET-54199) and [HTTP Timeout Ticket](https://kareodev.atlassian.net/browse/NET-54305)
* Ensure that the changes are compatible downstream in the Apigee Northbound External Loadbalance Module
* Confirm that there are no outstanding changes related to SSL Policy (timeout changes have not yet been applied, so there is expected to be a diff there): `terragrunt plan --terragrunt-working-dir=terraform/tebra-apigee/apigee/apigee-northbound-external/`