### PR TITLE
feat(NET-54305): Add Supporting Variables to PSC Module

### DIFF
--- a/modules/nb-psc-l7xlb/main.tf
+++ b/modules/nb-psc-l7xlb/main.tf
@@ -15,13 +15,15 @@
  */
 
 resource "google_compute_backend_service" "psc_backend" {
-  project               = var.project_id
-  name                  = "${var.name}-backend"
-  port_name             = "https"
-  protocol              = "HTTPS"
-  load_balancing_scheme = "EXTERNAL_MANAGED"
-  security_policy       = var.security_policy
-  edge_security_policy  = var.edge_security_policy
+  project                         = var.project_id
+  name                            = "${var.name}-backend"
+  port_name                       = "http"
+  protocol                        = "HTTPS"
+  load_balancing_scheme           = "EXTERNAL_MANAGED"
+  locality_lb_policy              = var.locality_lb_policy
+  security_policy                 = var.security_policy
+  edge_security_policy            = var.edge_security_policy
+  connection_draining_timeout_sec = var.connection_draining_timeout_sec
   dynamic "backend" {
     for_each = var.psc_negs
     content {

--- a/modules/nb-psc-l7xlb/variables.tf
+++ b/modules/nb-psc-l7xlb/variables.tf
@@ -72,3 +72,15 @@ variable "http_keep_alive_timeout_sec" {
   type        = string
   default     = 300
 }
+
+variable "connection_draining_timeout_sec" {
+  description = "(Optional) Time for which instance will be drained (not accept new connections, but still work to finish started)."
+  type        = string
+  default     = 300
+}
+
+variable "locality_lb_policy" {
+  description = "(Optional) The load balancing algorithm used within the scope of the locality."
+  type        = string
+  default     = "ROUND_ROBIN"
+}


### PR DESCRIPTION
[NET-54305]

# Description
Add support for the PSC module for the following changes:

-  Added `locality_lb_policy`: sets the loadbalancing algorithm to `ROUND_ROBIN` by default.
- Added `connection_draining_timeout_sec`: configures connection draining
- Changed `port_name`: from "https" to "http"

These changes capture the manual changes requested in the ticket.

To test:

- Review the changes to the module
- Confirm that there are no outstanding changes in the plans described in https://github.com/kareo-netops/devops-terraform/pull/655

[NET-54305]: https://kareodev.atlassian.net/browse/NET-54305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ